### PR TITLE
Add macOS dossier helper pipeline and GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # dossierhelper
-A helper to create dossiers
+
+A macOS-focused helper application to discover, classify, and report on tenure and promotion dossier artifacts.
+
+## Features
+
+* **Three-pass discovery pipeline** that starts with a fast surface scan, performs deeper metadata and text extraction, and culminates in a detailed reporting pass.
+* **Rule-based classification** driven by the unit-provided tenure & promotion matrix for Teaching, Service, Advising, Forms, and Scholarly/Creative artifacts.
+* **macOS Finder tag integration** to apply consistent color/label tags that mirror dossier destinations.
+* **Tkinter desktop UI** that allows you to choose search roots, limit scans by calendar year, and launch each pass individually or in sequence.
+* **Extensible metadata extraction** with hooks for Spotlight (`mdls`) data, PDF text parsing, and custom author-hour annotations.
+
+## Getting Started
+
+1. Install Python 3.10+ on macOS.
+2. Clone this repository and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[mac]
+   ```
+
+3. Launch the GUI:
+
+   ```bash
+   dossierhelper
+   ```
+
+## Configuration
+
+The application loads optional YAML configuration files that define search roots, ignored directories, and author metadata. See [`example_config.yaml`](example_config.yaml) for a template.
+
+## Development Notes
+
+* The GUI and pipeline code were designed for macOS Monterey and newer.
+* Text extraction relies on `pdfminer.six` when available; additional extractors can be registered in `dossierhelper/text.py`.
+* Finder tag updates require `pyobjc` so the tool can call the Cocoa APIs for tagging. When tags cannot be written, the pipeline logs a warning and continues.
+
+## License
+
+MIT

--- a/docs/rules_matrix.md
+++ b/docs/rules_matrix.md
@@ -1,0 +1,24 @@
+# Tenure & Promotion Artifact Classification Rules
+
+| Artifact Type                                            | Category             | Subcategory / Rule                 | Portfolio Destination              | Source Rationale                                                   |
+| -------------------------------------------------------- | -------------------- | ---------------------------------- | ---------------------------------- | ------------------------------------------------------------------ |
+| Concert programs (ensemble under your direction)         | Teaching             | Ensemble Leadership                | Primary PDF → Teaching Evidence    | CBDNA: teaching includes ensemble prep & communication             |
+| Student assessment/feedback (e.g., D2L quiz eval)        | Teaching             | Course Assessment                  | Primary PDF → Teaching Evidence    | Dept rules: student evals show teaching effectiveness              |
+| Repertoire feedback report (pedagogy course)             | Teaching             | Course Material                    | Primary PDF → Teaching Evidence    | CMU: direct evidence of pedagogy & learning outcomes               |
+| Marching member info forms (roster, recruiting data)     | Service              | Recruiting (admin evidence)        | Primary PDF → Service Evidence     | CBDNA: recruitment/retention is service if framed administratively |
+| Recruiting emails (prospect communication)               | Service              | Recruiting (outreach)              | Primary PDF → Service Evidence     | CBDNA: outreach recruiting = service                               |
+| Vendor orders (e.g., RushOrderTees uniforms)             | Service              | Logistics / Ops                    | Appendices                         | CMU: operational docs belong in Appendices                         |
+| Refund notifications / receipts                          | Service              | Logistics / Ops                    | Appendices                         | Same as above                                                      |
+| Leadership application instructions (mentorship emails)  | Teaching             | Mentorship / Leadership Dev.       | Primary PDF → Teaching Evidence    | Dept: leadership development = teaching                            |
+| Drill design file (.sib, .musx)                          | Scholarly / Creative | Creative Output (arranging/design) | Primary PDF → Scholarship Evidence | CBDNA: drill/arranging = creative scholarship                      |
+| Compositions / arrangements (PDF, Sibelius)              | Scholarly / Creative | Creative Output                    | Primary PDF → Scholarship Evidence | Same                                                               |
+| Literature review (.bib, draft)                          | Scholarly / Creative | Research Prep                      | Primary PDF → Scholarship Evidence | Dept rules: lit reviews = scholarship prep                         |
+| Recordings / publicity materials                         | Scholarly / Creative | Creative Output                    | Primary PDF → Scholarship Evidence | CBDNA: recordings & publicity = creative work                      |
+| Community/athletic performances (e.g., pep band at game) | Service              | University Visibility              | Primary PDF → Service Evidence     | CBDNA: all pep/marching performances = service to community        |
+| Adjudicating festivals / clinics                         | Service              | Professional Engagement            | Primary PDF → Service Evidence     | Dept rules: adjudication/clinics = service                         |
+| Advising load reports                                    | Advising             | Formal Advising                    | Primary PDF → Advising Summary     | Dept rules: advising ≥5%, requires evidence                        |
+| Orientation materials, grad plan forms                   | Advising             | Advising Artifacts                 | Primary PDF → Advising Evidence    | CMU portfolio instructions                                         |
+| Annual evaluation summaries                              | Form                 | Annual Eval                        | SummaryTable (in Primary PDF)      | CMU: required form                                                 |
+| Notice of Intent / cover sheet                           | Form                 | Cover Sheet                        | Form (separate PDF)                | CMU portfolio instructions                                         |
+
+Use this table when extending or refining the automated classifier. The `dossierhelper.classifier` module ships with rule definitions that mirror this matrix.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,22 @@
+search_roots:
+  - ~/Documents/Dossier
+  - ~/Desktop
+ignored_directories:
+  - .git
+  - node_modules
+extensions:
+  teaching:
+    - .pdf
+    - .docx
+    - .pages
+  service:
+    - .pdf
+    - .xlsx
+metadata:
+  author: "Your Name"
+  campus_roles:
+    - Director of Bands
+    - Advisor
+reporting:
+  output_directory: ~/Documents/DossierReports
+  include_text_snippets: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dossierhelper"
+version = "0.1.0"
+description = "macOS dossier artifact discovery and classification tool"
+readme = "README.md"
+authors = [{name = "Your Name"}]
+requires-python = ">=3.10"
+dependencies = [
+    "python-dateutil>=2.8.2",
+    "rich>=13.5.2",
+    "pyyaml>=6.0",
+    "pdfminer.six>=20221105",
+]
+
+[project.optional-dependencies]
+mac = [
+    "pyobjc>=9.0",
+]
+
+[project.scripts]
+dossierhelper = "dossierhelper.gui:main"

--- a/src/dossierhelper/__init__.py
+++ b/src/dossierhelper/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for dossierhelper."""
+
+from .config import AppConfig
+from .pipeline import DossierPipeline
+
+__all__ = ["AppConfig", "DossierPipeline"]

--- a/src/dossierhelper/classifier.py
+++ b/src/dossierhelper/classifier.py
@@ -1,0 +1,104 @@
+"""Rule-based artifact classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Iterable, Optional
+
+from dateutil import parser as date_parser
+
+
+class Category(Enum):
+    TEACHING = "Teaching"
+    SERVICE = "Service"
+    SCHOLARLY = "Scholarly / Creative"
+    ADVISING = "Advising"
+    FORM = "Form"
+
+
+@dataclass
+class ClassificationResult:
+    category: Category
+    subcategory: str
+    portfolio_destination: str
+    rationale: str
+
+
+_RULES: list[tuple[tuple[str, ...], ClassificationResult]] = [
+    (("concert program", "ensemble"), ClassificationResult(Category.TEACHING, "Ensemble Leadership", "Primary PDF → Teaching Evidence", "Ensemble programs demonstrate instructional leadership.")),
+    (("student assessment", "quiz", "evaluation"), ClassificationResult(Category.TEACHING, "Course Assessment", "Primary PDF → Teaching Evidence", "Student feedback shows teaching effectiveness.")),
+    (("repertoire feedback", "pedagogy"), ClassificationResult(Category.TEACHING, "Course Material", "Primary PDF → Teaching Evidence", "Pedagogical material documents learning outcomes.")),
+    (("member info", "roster"), ClassificationResult(Category.SERVICE, "Recruiting (admin evidence)", "Primary PDF → Service Evidence", "Recruitment management is classified as service.")),
+    (("recruiting email", "prospect"), ClassificationResult(Category.SERVICE, "Recruiting (outreach)", "Primary PDF → Service Evidence", "Outreach recruiting is a service activity.")),
+    (("vendor order", "invoice", "receipt"), ClassificationResult(Category.SERVICE, "Logistics / Ops", "Appendices", "Operational logistics go to appendices.")),
+    (("leadership application", "mentorship"), ClassificationResult(Category.TEACHING, "Mentorship / Leadership Dev.", "Primary PDF → Teaching Evidence", "Leadership development counts as teaching.")),
+    (("drill design", "musx", "sib"), ClassificationResult(Category.SCHOLARLY, "Creative Output", "Primary PDF → Scholarship Evidence", "Design files are creative scholarship.")),
+    (("composition", "arrangement"), ClassificationResult(Category.SCHOLARLY, "Creative Output", "Primary PDF → Scholarship Evidence", "Compositions qualify as scholarship.")),
+    (("literature review", "bib"), ClassificationResult(Category.SCHOLARLY, "Research Prep", "Primary PDF → Scholarship Evidence", "Lit reviews prepare scholarship.")),
+    (("recording", "publicity"), ClassificationResult(Category.SCHOLARLY, "Creative Output", "Primary PDF → Scholarship Evidence", "Recordings promote creative work.")),
+    (("community performance", "pep band", "game"), ClassificationResult(Category.SERVICE, "University Visibility", "Primary PDF → Service Evidence", "Campus performances expand visibility.")),
+    (("clinic", "adjudicat"), ClassificationResult(Category.SERVICE, "Professional Engagement", "Primary PDF → Service Evidence", "Clinics and adjudication are service.")),
+    (("advising load", "advisee"), ClassificationResult(Category.ADVISING, "Formal Advising", "Primary PDF → Advising Summary", "Advising reports document workload.")),
+    (("orientation", "grad plan"), ClassificationResult(Category.ADVISING, "Advising Artifacts", "Primary PDF → Advising Evidence", "Advising materials support advising.")),
+    (("annual evaluation",), ClassificationResult(Category.FORM, "Annual Eval", "SummaryTable (in Primary PDF)", "Annual evaluations are required forms.")),
+    (("notice of intent", "cover sheet"), ClassificationResult(Category.FORM, "Cover Sheet", "Form (separate PDF)", "Cover sheets belong in the form section.")),
+]
+
+
+def normalize(text: str) -> str:
+    return text.lower().strip()
+
+
+def _tokenize(text: str) -> set[str]:
+    text = normalize(text)
+    tokens: set[str] = set()
+    for part in text.replace("_", " ").replace("-", " ").split():
+        tokens.add(part)
+    return tokens
+
+
+def classify(path: Path, *, metadata: Optional[dict[str, str]] = None, text: Optional[str] = None) -> Optional[ClassificationResult]:
+    """Return a classification result if a rule matches."""
+
+    haystacks: list[str] = [path.stem, path.suffix]
+    if metadata:
+        haystacks.extend(str(value) for value in metadata.values() if isinstance(value, str))
+    if text:
+        haystacks.append(text[:500])
+
+    tokens: set[str] = set()
+    for haystack in haystacks:
+        tokens.update(_tokenize(haystack))
+
+    for keywords, result in _RULES:
+        if all(any(token.startswith(keyword) for token in tokens) for keyword in keywords):
+            return result
+    return None
+
+
+def filter_by_year(paths: Iterable[Path], *, year: Optional[int], metadata_lookup: callable[[Path], dict[str, str]]) -> list[Path]:
+    """Filter artifacts using creation year metadata or filesystem timestamps."""
+
+    if year is None:
+        return list(paths)
+
+    filtered: list[Path] = []
+    for path in paths:
+        info = metadata_lookup(path)
+        date_str = info.get("kMDItemContentCreationDate") or info.get("creation_date")
+        if not date_str:
+            stat = path.stat()
+            created = datetime.fromtimestamp(stat.st_ctime)
+            if created.year == year:
+                filtered.append(path)
+            continue
+        try:
+            parsed_date = date_parser.parse(str(date_str))
+        except (ValueError, TypeError):
+            continue
+        if parsed_date.year == year:
+            filtered.append(path)
+    return filtered

--- a/src/dossierhelper/config.py
+++ b/src/dossierhelper/config.py
@@ -1,0 +1,67 @@
+"""Configuration loading utilities for dossierhelper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+
+
+def _expand_paths(paths: Iterable[str]) -> List[Path]:
+    return [Path(p).expanduser().resolve() for p in paths]
+
+
+@dataclass
+class ReportingConfig:
+    """Output and analytics configuration."""
+
+    output_directory: Path
+    include_text_snippets: bool = False
+
+
+@dataclass
+class AppConfig:
+    """User configurable settings loaded from YAML."""
+
+    search_roots: List[Path]
+    ignored_directories: List[str] = field(default_factory=list)
+    extensions: dict[str, List[str]] = field(default_factory=dict)
+    metadata: dict[str, str | list[str]] = field(default_factory=dict)
+    reporting: Optional[ReportingConfig] = None
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "AppConfig":
+        data = yaml.safe_load(Path(path).read_text()) or {}
+        search_roots = _expand_paths(data.get("search_roots", ["."]))
+        ignored_directories = data.get("ignored_directories", [])
+        extensions = data.get("extensions", {})
+        metadata = data.get("metadata", {})
+        reporting_data = data.get("reporting")
+        reporting = None
+        if reporting_data:
+            output_dir = Path(reporting_data["output_directory"]).expanduser().resolve()
+            reporting = ReportingConfig(
+                output_directory=output_dir,
+                include_text_snippets=bool(reporting_data.get("include_text_snippets", False)),
+            )
+        return cls(
+            search_roots=search_roots,
+            ignored_directories=ignored_directories,
+            extensions=extensions,
+            metadata=metadata,
+            reporting=reporting,
+        )
+
+    def should_scan_path(self, path: Path) -> bool:
+        """Return True if the provided path should be processed."""
+
+        parts = {part for part in path.parts}
+        return not any(ignored in parts for ignored in self.ignored_directories)
+
+
+DEFAULT_CONFIG = AppConfig(
+    search_roots=[Path.home()],
+    ignored_directories=[".git", "node_modules", "__pycache__"],
+)

--- a/src/dossierhelper/gui.py
+++ b/src/dossierhelper/gui.py
@@ -1,0 +1,115 @@
+"""Tkinter desktop UI for dossierhelper."""
+
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+
+from .config import AppConfig, DEFAULT_CONFIG
+from .pipeline import DossierPipeline
+
+console = Console()
+
+
+class Application(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Dossier Helper")
+        self.geometry("640x320")
+        self.config = DEFAULT_CONFIG
+        self.pipeline = DossierPipeline(self.config)
+        self.selected_year: Optional[int] = None
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        self.columnconfigure(1, weight=1)
+
+        tk.Label(self, text="Configuration file (optional)").grid(row=0, column=0, padx=8, pady=8, sticky="w")
+        self.config_entry = tk.Entry(self)
+        self.config_entry.grid(row=0, column=1, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Browse", command=self._choose_config).grid(row=0, column=2, padx=8, pady=8)
+
+        tk.Label(self, text="Limit to calendar year").grid(row=1, column=0, padx=8, pady=8, sticky="w")
+        self.year_var = tk.StringVar()
+        self.year_entry = tk.Entry(self, textvariable=self.year_var)
+        self.year_entry.grid(row=1, column=1, padx=8, pady=8, sticky="ew")
+
+        tk.Button(self, text="Run Pass 1", command=self._run_pass_one).grid(row=2, column=0, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run Pass 2", command=self._run_pass_two).grid(row=2, column=1, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run Pass 3", command=self._run_pass_three).grid(row=2, column=2, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run All", command=self._run_all).grid(row=3, column=0, columnspan=3, padx=8, pady=16, sticky="ew")
+
+        self.status_var = tk.StringVar(value="Ready")
+        tk.Label(self, textvariable=self.status_var, anchor="w").grid(row=4, column=0, columnspan=3, padx=8, pady=8, sticky="ew")
+
+    def _choose_config(self) -> None:
+        selected = filedialog.askopenfilename(title="Select configuration", filetypes=[("YAML", "*.yaml"), ("YML", "*.yml")])
+        if selected:
+            self.config_entry.delete(0, tk.END)
+            self.config_entry.insert(0, selected)
+            self.config = AppConfig.from_yaml(selected)
+            self.pipeline = DossierPipeline(self.config)
+            self.status_var.set(f"Loaded configuration from {selected}")
+
+    def _resolve_year(self) -> Optional[int]:
+        value = self.year_var.get().strip()
+        if not value:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            messagebox.showerror("Invalid year", "Please enter a valid year (e.g., 2023)")
+            return None
+
+    def _run_pass_one(self) -> None:
+        self._run_async(lambda: self.pipeline.pass_one_surface_scan(year=self._resolve_year()), stage="pass1")
+
+    def _run_pass_two(self) -> None:
+        if not hasattr(self, "_pass_one_results"):
+            messagebox.showwarning("Run pass one first", "Please run pass one before pass two.")
+            return
+        self._run_async(lambda: self.pipeline.pass_two_deep_analysis(self._pass_one_results), stage="pass2")
+
+    def _run_pass_three(self) -> None:
+        if not hasattr(self, "_pass_two_results"):
+            messagebox.showwarning("Run pass two first", "Please run pass two before pass three.")
+            return
+        self._run_async(lambda: self.pipeline.pass_three_report(self._pass_two_results), stage="pass3")
+
+    def _run_all(self) -> None:
+        self._run_async(lambda: self.pipeline.run_all(year=self._resolve_year()), stage="all")
+
+    def _run_async(self, func, *, stage: str) -> None:
+        def worker() -> None:
+            try:
+                result = func()
+                if stage == "pass1" and isinstance(result, list):
+                    self._pass_one_results = result  # type: ignore[attr-defined]
+                    messagebox.showinfo("Pass 1 complete", f"Identified {len(result)} candidate artifacts.")
+                elif stage == "pass2" and isinstance(result, list):
+                    self._pass_two_results = result  # type: ignore[attr-defined]
+                    messagebox.showinfo("Pass 2 complete", f"Analyzed {len(result)} artifacts.")
+                elif stage in {"pass3", "all"} and isinstance(result, Path):
+                    messagebox.showinfo("Report generated", f"Report saved to {result}")
+            except Exception as exc:  # noqa: BLE001
+                console.log(f"[red]Error running pipeline: {exc}")
+                messagebox.showerror("Pipeline error", str(exc))
+            finally:
+                self.status_var.set("Ready")
+
+        self.status_var.set(f"Running {stage}...")
+        threading.Thread(target=worker, daemon=True).start()
+
+
+def main() -> None:
+    app = Application()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dossierhelper/metadata.py
+++ b/src/dossierhelper/metadata.py
@@ -1,0 +1,69 @@
+"""macOS metadata utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from rich.console import Console
+
+console = Console()
+
+
+@dataclass
+class ArtifactMetadata:
+    path: Path
+    raw: dict[str, str]
+    finder_tags: List[str]
+
+
+def run_mdls(path: Path) -> dict[str, str]:
+    """Fetch Spotlight metadata via mdls."""
+
+    try:
+        result = subprocess.run(
+            ["mdls", "-name", "kMDItemContentCreationDate", "-name", "kMDItemKind", "-name", "kMDItemUserTags", str(path)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        return {}
+
+    metadata: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = [part.strip() for part in line.split("=", 1)]
+        metadata[key] = value.strip().strip('"')
+    return metadata
+
+
+def read_finder_tags(path: Path, *, metadata: dict[str, str] | None = None) -> List[str]:
+    metadata = metadata or run_mdls(path)
+    tags = metadata.get("kMDItemUserTags", "")
+    if tags.startswith("(") and tags.endswith(")"):
+        tags = tags[1:-1]
+    return [tag.strip().strip('"') for tag in tags.split(",") if tag.strip()]
+
+
+def write_finder_tags(path: Path, tags: Iterable[str]) -> None:
+    tag_list = list(tags)
+    try:
+        from Cocoa import NSURL
+        from Foundation import NSArray
+
+        url = NSURL.fileURLWithPath_(str(path))
+        NSArray.arrayWithArray_(tag_list)
+        url.setResourceValue_forKey_error_(tag_list, "NSURLTagNamesKey", None)
+    except Exception as exc:  # noqa: BLE001
+        console.log(f"[yellow]Unable to update Finder tags for {path}: {exc}")
+
+
+def gather_metadata(path: Path) -> ArtifactMetadata:
+    raw = run_mdls(path)
+    tags = read_finder_tags(path, metadata=raw)
+    return ArtifactMetadata(path=path, raw=raw, finder_tags=tags)

--- a/src/dossierhelper/pipeline.py
+++ b/src/dossierhelper/pipeline.py
@@ -1,0 +1,134 @@
+"""Three-pass dossier processing pipeline."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+from rich.console import Console
+from rich.progress import Progress
+
+from . import classifier
+from .classifier import ClassificationResult
+from .config import AppConfig, DEFAULT_CONFIG
+from .metadata import gather_metadata, write_finder_tags
+from .text import extract_text
+
+console = Console()
+
+
+@dataclass
+class Artifact:
+    path: Path
+    metadata: dict[str, str] = field(default_factory=dict)
+    classification: Optional[ClassificationResult] = None
+    text: Optional[str] = None
+    hours_spent: float | None = None
+
+
+class DossierPipeline:
+    def __init__(self, config: Optional[AppConfig] = None) -> None:
+        self.config = config or DEFAULT_CONFIG
+
+    def pass_one_surface_scan(self, *, year: Optional[int] = None) -> List[Artifact]:
+        console.log("Starting pass one (surface scan)...")
+        candidates: list[Path] = []
+        for root in self.config.search_roots:
+            if not root.exists():
+                console.log(f"[yellow]Search root {root} does not exist; skipping.")
+                continue
+            for path in _iter_files(root):
+                if not path.is_file():
+                    continue
+                if not self.config.should_scan_path(path):
+                    continue
+                candidates.append(path)
+        filtered = classifier.filter_by_year(candidates, year=year, metadata_lookup=lambda p: gather_metadata(p).raw)
+        return [Artifact(path=path) for path in filtered]
+
+    def pass_two_deep_analysis(self, artifacts: Iterable[Artifact], *, apply_tags: bool = True) -> List[Artifact]:
+        console.log("Starting pass two (deep analysis)...")
+        enriched: List[Artifact] = []
+        artifacts_list = list(artifacts)
+        with Progress() as progress:
+            task = progress.add_task("Analyzing artifacts", total=len(artifacts_list))
+            for artifact in artifacts_list:
+                meta = gather_metadata(artifact.path)
+                artifact.metadata = meta.raw
+                artifact.text = extract_text(artifact.path)
+                artifact.classification = classifier.classify(artifact.path, metadata=meta.raw, text=artifact.text)
+                artifact.hours_spent = _estimate_hours(artifact, self.config.metadata)
+                if apply_tags and artifact.classification:
+                    write_finder_tags(artifact.path, _finder_tags_for(artifact.classification))
+                enriched.append(artifact)
+                progress.advance(task)
+        return enriched
+
+    def pass_three_report(self, artifacts: Iterable[Artifact], *, output: Optional[Path] = None) -> Path:
+        console.log("Starting pass three (reporting)...")
+        artifacts_list = list(artifacts)
+        if output is None:
+            output = Path.cwd() / "dossier_report.csv"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("w", newline="") as csvfile:
+            writer = csv.DictWriter(
+                csvfile,
+                fieldnames=["path", "category", "subcategory", "destination", "rationale", "hours_spent"],
+            )
+            writer.writeheader()
+            for artifact in artifacts_list:
+                classification = artifact.classification
+                writer.writerow(
+                    {
+                        "path": str(artifact.path),
+                        "category": classification.category.value if classification else "Unclassified",
+                        "subcategory": classification.subcategory if classification else "",
+                        "destination": classification.portfolio_destination if classification else "",
+                        "rationale": classification.rationale if classification else "",
+                        "hours_spent": artifact.hours_spent or "",
+                    }
+                )
+        return output
+
+    def run_all(self, *, year: Optional[int] = None, apply_tags: bool = True) -> Path:
+        artifacts = self.pass_one_surface_scan(year=year)
+        enriched = self.pass_two_deep_analysis(artifacts, apply_tags=apply_tags)
+        reporting_path = None
+        if self.config.reporting:
+            output_dir = self.config.reporting.output_directory
+            output_dir.mkdir(parents=True, exist_ok=True)
+            reporting_path = self.pass_three_report(
+                enriched,
+                output=output_dir / f"dossier_report_{year or 'all'}.csv",
+            )
+        else:
+            reporting_path = self.pass_three_report(enriched)
+        return reporting_path
+
+
+def _finder_tags_for(result: ClassificationResult) -> List[str]:
+    return [result.category.value, result.portfolio_destination]
+
+
+def _estimate_hours(artifact: Artifact, metadata: dict[str, str | list[str]]) -> float | None:
+    author = metadata.get("author") if isinstance(metadata.get("author"), str) else None
+    if not author:
+        return None
+    text = artifact.text or ""
+    marker = "HoursSpent:"
+    if marker in text:
+        try:
+            return float(text.split(marker, 1)[1].split()[0])
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
+def _iter_files(root: Path) -> Iterator[Path]:
+    try:
+        yield from root.rglob("*")
+    except PermissionError as exc:  # noqa: BLE001
+        console.log(f"[yellow]Permission denied while scanning {root}: {exc}")
+        return

--- a/src/dossierhelper/text.py
+++ b/src/dossierhelper/text.py
@@ -1,0 +1,33 @@
+"""Text extraction helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict
+
+from rich.console import Console
+
+console = Console()
+
+_EXTRACTORS: Dict[str, Callable[[Path], str]] = {}
+
+
+def register_extractor(suffix: str, func: Callable[[Path], str]) -> None:
+    _EXTRACTORS[suffix.lower()] = func
+
+
+def extract_text(path: Path) -> str:
+    extractor = _EXTRACTORS.get(path.suffix.lower())
+    if extractor:
+        try:
+            return extractor(path)
+        except Exception as exc:  # noqa: BLE001
+            console.log(f"[yellow]Extractor for {path} failed: {exc}")
+    if path.suffix.lower() == ".pdf":
+        try:
+            from pdfminer.high_level import extract_text as pdf_extract
+
+            return pdf_extract(str(path))
+        except Exception as exc:  # noqa: BLE001
+            console.log(f"[yellow]Falling back from PDF extraction for {path}: {exc}")
+    return ""


### PR DESCRIPTION
## Summary
- scaffold a Python package with dependencies and entry point for the dossier helper application
- implement configuration handling, artifact classification rules, and a three-pass processing pipeline with Finder tag integration
- add a Tkinter GUI for running the passes and sample configuration and documentation for the classification matrix

## Testing
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68d78d710364832294ed194a30e9f02d