### PR TITLE
Ensure macOS Python 3 requirements are enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ A macOS-focused helper application to discover, classify, and report on tenure a
 2. Clone this repository and install dependencies:
 
    ```bash
-   python -m venv .venv
+   python3 -m venv .venv
    source .venv/bin/activate
-   pip install -e .[mac]
+   python3 -m pip install -e .[mac]
    ```
 
 3. Launch the GUI:

--- a/src/dossierhelper/gui.py
+++ b/src/dossierhelper/gui.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Optional
+
+import platform
+import sys
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
-from pathlib import Path
-from typing import Optional
 
 from rich.console import Console
 
@@ -106,7 +109,22 @@ class Application(tk.Tk):
         threading.Thread(target=worker, daemon=True).start()
 
 
+def _ensure_supported_environment() -> None:
+    """Validate that the application is running on a supported platform."""
+
+    if sys.version_info < (3, 10):
+        raise SystemExit(
+            "Dossier Helper requires Python 3.10 or newer. Please upgrade Python before launching the app."
+        )
+
+    if platform.system() != "Darwin":
+        console.log(
+            "[yellow]Dossier Helper is optimized for macOS. Some functionality, such as Finder tag integration, may be unavailable on this platform."
+        )
+
+
 def main() -> None:
+    _ensure_supported_environment()
     app = Application()
     app.mainloop()
 


### PR DESCRIPTION
## Summary
- clarify the macOS setup instructions to use python3 tooling when creating the virtual environment and installing dependencies
- add a startup guard that enforces Python 3.10+ and logs a warning when the GUI is launched on non-macOS platforms

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d7e51d8a748322a7d7cdca724d6d63