### PR TITLE
Clarify zsh extras usage for pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A macOS-focused helper application to discover, classify, and report on tenure a
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   python3 -m pip install -e .[mac]
+   # If you use zsh, remember to quote the extras specifier to avoid globbing.
+   python3 -m pip install -e '.[mac]'
    ```
 
 3. Launch the GUI:


### PR DESCRIPTION
## Summary
- add a note to the macOS installation instructions explaining that zsh users should quote the extras specifier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e68dc9848322b6c4c413ca358789