### PR TITLE
Enhance GUI guidance and progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A macOS-focused helper application to discover, classify, and report on tenure a
 * **Three-pass discovery pipeline** that starts with a fast surface scan, performs deeper metadata and text extraction, and culminates in a detailed reporting pass.
 * **Rule-based classification** driven by the unit-provided tenure & promotion matrix for Teaching, Service, Advising, Forms, and Scholarly/Creative artifacts.
 * **macOS Finder tag integration** to apply consistent color/label tags that mirror dossier destinations.
-* **Tkinter desktop UI** that allows you to choose search roots, limit scans by calendar year, and launch each pass individually or in sequence.
+* **Tkinter desktop UI** that allows you to choose search roots, limit scans by calendar year, launch each pass individually or in sequence, and watch a progress console full of dossier stats and delightfully retro quips.
 * **Extensible metadata extraction** with hooks for Spotlight (`mdls`) data, PDF text parsing, and custom author-hour annotations.
 
 ## Getting Started
@@ -30,7 +30,7 @@ A macOS-focused helper application to discover, classify, and report on tenure a
 
 ## Configuration
 
-The application loads optional YAML configuration files that define search roots, ignored directories, and author metadata. See [`example_config.yaml`](example_config.yaml) for a template.
+The application loads optional YAML configuration files that define search roots, ignored directories, and author metadata. A bundled `example_config.yaml` is applied by default in the GUI so you have a ready-to-go starting point, and you can swap in your own file at any time. See [`example_config.yaml`](example_config.yaml) for the template contents.
 
 ## Development Notes
 

--- a/src/dossierhelper/config.py
+++ b/src/dossierhelper/config.py
@@ -61,7 +61,27 @@ class AppConfig:
         return not any(ignored in parts for ignored in self.ignored_directories)
 
 
-DEFAULT_CONFIG = AppConfig(
-    search_roots=[Path.home()],
-    ignored_directories=[".git", "node_modules", "__pycache__"],
-)
+def _default_config_path() -> Optional[Path]:
+    """Return the path to the packaged example configuration, if it exists."""
+
+    candidate = Path(__file__).resolve().parent.parent / "example_config.yaml"
+    return candidate if candidate.exists() else None
+
+
+def _load_default_config() -> AppConfig:
+    """Load the default configuration bundled with the project."""
+
+    example_path = _default_config_path()
+    if example_path:
+        try:
+            return AppConfig.from_yaml(example_path)
+        except Exception:  # noqa: BLE001
+            pass
+    return AppConfig(
+        search_roots=[Path.home()],
+        ignored_directories=[".git", "node_modules", "__pycache__"],
+    )
+
+
+DEFAULT_CONFIG = _load_default_config()
+DEFAULT_CONFIG_PATH = _default_config_path()

--- a/src/dossierhelper/gui.py
+++ b/src/dossierhelper/gui.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from queue import Queue, Empty
 from typing import Optional
 
 import platform
 import sys
 import threading
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, scrolledtext
 
 from rich.console import Console
 
-from .config import AppConfig, DEFAULT_CONFIG
-from .pipeline import DossierPipeline
+from .config import AppConfig, DEFAULT_CONFIG, DEFAULT_CONFIG_PATH
+from .pipeline import DossierPipeline, ProgressEvent
 
 console = Console()
 
@@ -27,28 +28,47 @@ class Application(tk.Tk):
         self.config = DEFAULT_CONFIG
         self.pipeline = DossierPipeline(self.config)
         self.selected_year: Optional[int] = None
+        self.log_queue: "Queue[str]" = Queue()
         self._build_widgets()
+        self._poll_log_queue()
 
     def _build_widgets(self) -> None:
         self.columnconfigure(1, weight=1)
 
-        tk.Label(self, text="Configuration file (optional)").grid(row=0, column=0, padx=8, pady=8, sticky="w")
+        tk.Label(self, text="Configuration file (optional)").grid(row=0, column=0, padx=8, pady=2, sticky="w")
         self.config_entry = tk.Entry(self)
-        self.config_entry.grid(row=0, column=1, padx=8, pady=8, sticky="ew")
+        self.config_entry.grid(row=0, column=1, padx=8, pady=2, sticky="ew")
         tk.Button(self, text="Browse", command=self._choose_config).grid(row=0, column=2, padx=8, pady=8)
+        tk.Label(
+            self,
+            text=(
+                "Leave blank to use the built-in example_config.yaml, which searches "
+                "Documents/Desktop and mirrors the dossier rules."
+            ),
+            wraplength=460,
+            justify="left",
+        ).grid(row=1, column=0, columnspan=3, padx=8, pady=(0, 8), sticky="w")
 
-        tk.Label(self, text="Limit to calendar year").grid(row=1, column=0, padx=8, pady=8, sticky="w")
+        tk.Label(self, text="Limit to calendar year").grid(row=2, column=0, padx=8, pady=8, sticky="w")
         self.year_var = tk.StringVar()
         self.year_entry = tk.Entry(self, textvariable=self.year_var)
-        self.year_entry.grid(row=1, column=1, padx=8, pady=8, sticky="ew")
+        self.year_entry.grid(row=2, column=1, padx=8, pady=8, sticky="ew")
 
-        tk.Button(self, text="Run Pass 1", command=self._run_pass_one).grid(row=2, column=0, padx=8, pady=8, sticky="ew")
-        tk.Button(self, text="Run Pass 2", command=self._run_pass_two).grid(row=2, column=1, padx=8, pady=8, sticky="ew")
-        tk.Button(self, text="Run Pass 3", command=self._run_pass_three).grid(row=2, column=2, padx=8, pady=8, sticky="ew")
-        tk.Button(self, text="Run All", command=self._run_all).grid(row=3, column=0, columnspan=3, padx=8, pady=16, sticky="ew")
+        tk.Button(self, text="Run Pass 1", command=self._run_pass_one).grid(row=3, column=0, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run Pass 2", command=self._run_pass_two).grid(row=3, column=1, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run Pass 3", command=self._run_pass_three).grid(row=3, column=2, padx=8, pady=8, sticky="ew")
+        tk.Button(self, text="Run All", command=self._run_all).grid(row=4, column=0, columnspan=3, padx=8, pady=12, sticky="ew")
 
         self.status_var = tk.StringVar(value="Ready")
-        tk.Label(self, textvariable=self.status_var, anchor="w").grid(row=4, column=0, columnspan=3, padx=8, pady=8, sticky="ew")
+        tk.Label(self, textvariable=self.status_var, anchor="w").grid(row=5, column=0, columnspan=3, padx=8, pady=(4, 0), sticky="ew")
+
+        self.progress_output = scrolledtext.ScrolledText(self, height=8, state="disabled", wrap="word")
+        self.progress_output.grid(row=6, column=0, columnspan=3, padx=8, pady=(4, 8), sticky="nsew")
+        self.rowconfigure(6, weight=1)
+
+        if DEFAULT_CONFIG_PATH:
+            self.config_entry.insert(0, str(DEFAULT_CONFIG_PATH))
+            self.status_var.set("Loaded bundled example configuration.")
 
     def _choose_config(self) -> None:
         selected = filedialog.askopenfilename(title="Select configuration", filetypes=[("YAML", "*.yaml"), ("YML", "*.yml")])
@@ -58,6 +78,7 @@ class Application(tk.Tk):
             self.config = AppConfig.from_yaml(selected)
             self.pipeline = DossierPipeline(self.config)
             self.status_var.set(f"Loaded configuration from {selected}")
+            self._queue_log("Configuration tuned up. Time to blow the dust off this 80s boombox and scan like it's 1986!")
 
     def _resolve_year(self) -> Optional[int]:
         value = self.year_var.get().strip()
@@ -70,22 +91,46 @@ class Application(tk.Tk):
             return None
 
     def _run_pass_one(self) -> None:
-        self._run_async(lambda: self.pipeline.pass_one_surface_scan(year=self._resolve_year()), stage="pass1")
+        self._run_async(
+            lambda: self.pipeline.pass_one_surface_scan(
+                year=self._resolve_year(),
+                progress_callback=self._queue_progress,
+            ),
+            stage="pass1",
+        )
 
     def _run_pass_two(self) -> None:
         if not hasattr(self, "_pass_one_results"):
             messagebox.showwarning("Run pass one first", "Please run pass one before pass two.")
             return
-        self._run_async(lambda: self.pipeline.pass_two_deep_analysis(self._pass_one_results), stage="pass2")
+        self._run_async(
+            lambda: self.pipeline.pass_two_deep_analysis(
+                self._pass_one_results,
+                progress_callback=self._queue_progress,
+            ),
+            stage="pass2",
+        )
 
     def _run_pass_three(self) -> None:
         if not hasattr(self, "_pass_two_results"):
             messagebox.showwarning("Run pass two first", "Please run pass two before pass three.")
             return
-        self._run_async(lambda: self.pipeline.pass_three_report(self._pass_two_results), stage="pass3")
+        self._run_async(
+            lambda: self.pipeline.pass_three_report(
+                self._pass_two_results,
+                progress_callback=self._queue_progress,
+            ),
+            stage="pass3",
+        )
 
     def _run_all(self) -> None:
-        self._run_async(lambda: self.pipeline.run_all(year=self._resolve_year()), stage="all")
+        self._run_async(
+            lambda: self.pipeline.run_all(
+                year=self._resolve_year(),
+                progress_callback=self._queue_progress,
+            ),
+            stage="all",
+        )
 
     def _run_async(self, func, *, stage: str) -> None:
         def worker() -> None:
@@ -93,12 +138,21 @@ class Application(tk.Tk):
                 result = func()
                 if stage == "pass1" and isinstance(result, list):
                     self._pass_one_results = result  # type: ignore[attr-defined]
-                    messagebox.showinfo("Pass 1 complete", f"Identified {len(result)} candidate artifacts.")
+                    messagebox.showinfo(
+                        "Pass 1 complete",
+                        f"Identified {len(result)} candidate artifacts. As Strong Bad would say, that's some deluxe paper shuffling!",
+                    )
                 elif stage == "pass2" and isinstance(result, list):
                     self._pass_two_results = result  # type: ignore[attr-defined]
-                    messagebox.showinfo("Pass 2 complete", f"Analyzed {len(result)} artifacts.")
+                    messagebox.showinfo(
+                        "Pass 2 complete",
+                        f"Analyzed {len(result)} artifacts. Cue the RedLetterMedia 'How embarrassing!' stinger for every misfiled folder.",
+                    )
                 elif stage in {"pass3", "all"} and isinstance(result, Path):
-                    messagebox.showinfo("Report generated", f"Report saved to {result}")
+                    messagebox.showinfo(
+                        "Report generated",
+                        f"Report saved to {result}. It's like a VHS training tape come to life, but with way better metadata.",
+                    )
             except Exception as exc:  # noqa: BLE001
                 console.log(f"[red]Error running pipeline: {exc}")
                 messagebox.showerror("Pipeline error", str(exc))
@@ -106,7 +160,43 @@ class Application(tk.Tk):
                 self.status_var.set("Ready")
 
         self.status_var.set(f"Running {stage}...")
+        self._queue_log(f"{stage.upper()} engaged. Cue the keytar solo!")
         threading.Thread(target=worker, daemon=True).start()
+
+    def _queue_progress(self, event: ProgressEvent) -> None:
+        details = event.message
+        if event.scanned_count is not None and event.total_candidates is not None:
+            details += f" | Scanned: {event.scanned_count}, Candidates: {event.total_candidates}"
+        elif event.scanned_count is not None:
+            details += f" | Processed: {event.scanned_count}"
+        if event.bucket_totals:
+            bucket_summary = ", ".join(f"{bucket}: {count}" for bucket, count in sorted(event.bucket_totals.items()))
+            details += f" | Buckets => {bucket_summary}"
+        if event.finder_tagged is not None:
+            tag_status = "Finder tag locked in" if event.finder_tagged else "Finder tag skipped"
+            details += f" | {tag_status}"
+        if event.stage == "pass2" and event.bucket == "Unclassified":
+            details += " | Whoops! Somebody call Mike Stoklasa because that one's getting the 'How embarrassing!' cut."
+        self._queue_log(details)
+
+    def _queue_log(self, message: str) -> None:
+        self.log_queue.put(message)
+
+    def _poll_log_queue(self) -> None:
+        try:
+            while True:
+                entry = self.log_queue.get_nowait()
+                self._append_log(entry)
+        except Empty:
+            pass
+        finally:
+            self.after(200, self._poll_log_queue)
+
+    def _append_log(self, message: str) -> None:
+        self.progress_output.configure(state="normal")
+        self.progress_output.insert(tk.END, message + "\n")
+        self.progress_output.see(tk.END)
+        self.progress_output.configure(state="disabled")
 
 
 def _ensure_supported_environment() -> None:

--- a/src/dossierhelper/pipeline.py
+++ b/src/dossierhelper/pipeline.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import csv
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional
+from typing import Callable, Iterable, Iterator, List, Optional
 
 from rich.console import Console
 from rich.progress import Progress
@@ -13,7 +14,7 @@ from rich.progress import Progress
 from . import classifier
 from .classifier import ClassificationResult
 from .config import AppConfig, DEFAULT_CONFIG
-from .metadata import gather_metadata, write_finder_tags
+from .metadata import gather_metadata, read_finder_tags, write_finder_tags
 from .text import extract_text
 
 console = Console()
@@ -28,13 +29,30 @@ class Artifact:
     hours_spent: float | None = None
 
 
+@dataclass
+class ProgressEvent:
+    stage: str
+    message: str
+    scanned_count: Optional[int] = None
+    total_candidates: Optional[int] = None
+    bucket: Optional[str] = None
+    bucket_totals: Optional[dict[str, int]] = None
+    finder_tagged: Optional[bool] = None
+
+
 class DossierPipeline:
     def __init__(self, config: Optional[AppConfig] = None) -> None:
         self.config = config or DEFAULT_CONFIG
 
-    def pass_one_surface_scan(self, *, year: Optional[int] = None) -> List[Artifact]:
+    def pass_one_surface_scan(
+        self,
+        *,
+        year: Optional[int] = None,
+        progress_callback: Optional[Callable[[ProgressEvent], None]] = None,
+    ) -> List[Artifact]:
         console.log("Starting pass one (surface scan)...")
         candidates: list[Path] = []
+        scanned_count = 0
         for root in self.config.search_roots:
             if not root.exists():
                 console.log(f"[yellow]Search root {root} does not exist; skipping.")
@@ -45,28 +63,79 @@ class DossierPipeline:
                 if not self.config.should_scan_path(path):
                     continue
                 candidates.append(path)
+                scanned_count += 1
+                if progress_callback:
+                    progress_callback(
+                        ProgressEvent(
+                            stage="pass1",
+                            message=f"Scanning {path.name}",
+                            scanned_count=scanned_count,
+                        )
+                    )
         filtered = classifier.filter_by_year(candidates, year=year, metadata_lookup=lambda p: gather_metadata(p).raw)
-        return [Artifact(path=path) for path in filtered]
+        artifacts = [Artifact(path=path) for path in filtered]
+        if progress_callback:
+            progress_callback(
+                ProgressEvent(
+                    stage="pass1",
+                    message=f"Surfaced {len(artifacts)} dossier hopefuls from {scanned_count} scanned items.",
+                    scanned_count=scanned_count,
+                    total_candidates=len(artifacts),
+                )
+            )
+        return artifacts
 
-    def pass_two_deep_analysis(self, artifacts: Iterable[Artifact], *, apply_tags: bool = True) -> List[Artifact]:
+    def pass_two_deep_analysis(
+        self,
+        artifacts: Iterable[Artifact],
+        *,
+        apply_tags: bool = True,
+        progress_callback: Optional[Callable[[ProgressEvent], None]] = None,
+    ) -> List[Artifact]:
         console.log("Starting pass two (deep analysis)...")
         enriched: List[Artifact] = []
         artifacts_list = list(artifacts)
+        bucket_totals: Counter[str] = Counter()
         with Progress() as progress:
             task = progress.add_task("Analyzing artifacts", total=len(artifacts_list))
-            for artifact in artifacts_list:
+            for index, artifact in enumerate(artifacts_list, start=1):
                 meta = gather_metadata(artifact.path)
                 artifact.metadata = meta.raw
                 artifact.text = extract_text(artifact.path)
                 artifact.classification = classifier.classify(artifact.path, metadata=meta.raw, text=artifact.text)
                 artifact.hours_spent = _estimate_hours(artifact, self.config.metadata)
+                bucket = "Unclassified"
+                if artifact.classification:
+                    bucket = artifact.classification.portfolio_destination
+                bucket_totals[bucket] += 1
+                finder_tagged = False
                 if apply_tags and artifact.classification:
-                    write_finder_tags(artifact.path, _finder_tags_for(artifact.classification))
+                    desired_tags = _finder_tags_for(artifact.classification)
+                    write_finder_tags(artifact.path, desired_tags)
+                    updated_tags = read_finder_tags(artifact.path)
+                    finder_tagged = all(tag in updated_tags for tag in desired_tags)
                 enriched.append(artifact)
+                if progress_callback:
+                    progress_callback(
+                        ProgressEvent(
+                            stage="pass2",
+                            message=f"Sorted {artifact.path.name} into {bucket}.",
+                            scanned_count=index,
+                            bucket=bucket,
+                            bucket_totals=dict(bucket_totals),
+                            finder_tagged=finder_tagged if apply_tags else None,
+                        )
+                    )
                 progress.advance(task)
         return enriched
 
-    def pass_three_report(self, artifacts: Iterable[Artifact], *, output: Optional[Path] = None) -> Path:
+    def pass_three_report(
+        self,
+        artifacts: Iterable[Artifact],
+        *,
+        output: Optional[Path] = None,
+        progress_callback: Optional[Callable[[ProgressEvent], None]] = None,
+    ) -> Path:
         console.log("Starting pass three (reporting)...")
         artifacts_list = list(artifacts)
         if output is None:
@@ -90,11 +159,28 @@ class DossierPipeline:
                         "hours_spent": artifact.hours_spent or "",
                     }
                 )
+        if progress_callback:
+            progress_callback(
+                ProgressEvent(
+                    stage="pass3",
+                    message=f"Report locked in at {output}",
+                )
+            )
         return output
 
-    def run_all(self, *, year: Optional[int] = None, apply_tags: bool = True) -> Path:
-        artifacts = self.pass_one_surface_scan(year=year)
-        enriched = self.pass_two_deep_analysis(artifacts, apply_tags=apply_tags)
+    def run_all(
+        self,
+        *,
+        year: Optional[int] = None,
+        apply_tags: bool = True,
+        progress_callback: Optional[Callable[[ProgressEvent], None]] = None,
+    ) -> Path:
+        artifacts = self.pass_one_surface_scan(year=year, progress_callback=progress_callback)
+        enriched = self.pass_two_deep_analysis(
+            artifacts,
+            apply_tags=apply_tags,
+            progress_callback=progress_callback,
+        )
         reporting_path = None
         if self.config.reporting:
             output_dir = self.config.reporting.output_directory
@@ -102,9 +188,10 @@ class DossierPipeline:
             reporting_path = self.pass_three_report(
                 enriched,
                 output=output_dir / f"dossier_report_{year or 'all'}.csv",
+                progress_callback=progress_callback,
             )
         else:
-            reporting_path = self.pass_three_report(enriched)
+            reporting_path = self.pass_three_report(enriched, progress_callback=progress_callback)
         return reporting_path
 
 


### PR DESCRIPTION
## Summary
- load the bundled example configuration by default and explain the optional config file in the GUI
- add a scrollable progress console with detailed artifact, bucket, and Finder tag updates plus retro-themed flavor text
- expose pipeline progress callbacks so the GUI can stream status updates while preserving report generation notifications

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d7fa75ba1083228aa5916c2c2918a0