### PR TITLE
Configure setuptools for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project]
 name = "dossierhelper"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- configure setuptools to look in the src directory when discovering packages so the `dossierhelper` module can be imported after installation

## Testing
- ⚠️ `pip install -e .` *(fails: cannot download setuptools due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80f4207b88322a596abc2c8d1c70d