### PR TITLE
Add multi-year filtering controls

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -133,11 +133,11 @@ Each file goes through:
 
 ## 🎮 Tips & Tricks
 
-### Scan Specific Year
+### Scan Specific Years
 ```
-Limit to calendar year: 2024
+Limit to calendar years: [2023] [2024]
 ```
-Only processes files from that year.
+Only processes files from the selected years.
 
 ### Run Individual Passes
 - **Pass 1**: Fast surface scan (discover files)


### PR DESCRIPTION
## Summary
- replace the single-year entry box with checkboxes for selecting 2021-2025 in the desktop UI
- allow the pipeline and classifier to filter by multiple years and update report naming accordingly
- refresh quickstart documentation to explain the new multi-year selection

## Testing
- python -m compileall src/dossierhelper

------
https://chatgpt.com/codex/tasks/task_e_68dad2f318e483228d501d1760c309a2