### PR TITLE
Fix duplicate setuptools config entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,3 @@ all = [
 [project.scripts]
 dossierhelper = "dossierhelper.gui:main"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-dir]
-"" = "src"


### PR DESCRIPTION
## Summary
- remove the duplicated setuptools configuration blocks from `pyproject.toml` so editable installs parse correctly

## Testing
- `pip install -e .` *(fails: environment cannot reach PyPI due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dafac8c21483228f358999706b68f8